### PR TITLE
Fix get_utun on linux/windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::io::Result;
+use std::io::{Error, ErrorKind, Result};
 use std::os::unix::io::FromRawFd;
 use std::net::UdpSocket;
 
@@ -22,7 +22,7 @@ pub fn get_utun() -> Result<(UdpSocket,String)> {
 
 #[cfg(not(target_os = "macos"))]
 pub fn get_utun() -> Result<(UdpSocket,String)> {
-    Err("Can open utun only on macos")
+    Err(ErrorKind::NotFound as Error)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub fn get_utun() -> Result<(UdpSocket,String)> {
 
 #[cfg(not(target_os = "macos"))]
 pub fn get_utun() -> Result<(UdpSocket,String)> {
-    Err(ErrorKind::NotFound as Error)
+    Err(Error::from(ErrorKind::NotFound))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The `get_utun` function should return a `std::io::Error`, not a `&str`